### PR TITLE
Parameterize median estimator for CI/PI and wire through controllers/UI

### DIFF
--- a/controllers/estimation/graphical_controller.py
+++ b/controllers/estimation/graphical_controller.py
@@ -5,7 +5,11 @@ from typing import Optional, Tuple
 import numpy as np
 import pandas as pd
 
-from core.estimation.inference.estimators import estimate_mean, estimate_sigma
+from core.estimation.inference.estimators import (
+    estimate_mean,
+    estimate_median,
+    estimate_sigma,
+)
 from core.estimation.inference.ci import (
     ci_mean_analytic,
     ci_mean_bootstrap,
@@ -149,6 +153,7 @@ def run_graphical_analysis(
             ecdf_conf_level=ecdf_conf_level,
             ecdf_add_normal=ecdf_add_normal,
             mean_estimator=mean_estimator,
+            median_estimator=median_estimator,
             sigma_estimator=sigma_estimator,
             trim_param=trim_param,
             winsor_limits=winsor_limits,
@@ -213,7 +218,7 @@ def _run_hist_or_pmf(
                     weights=weights,
                 )
             else:
-                hat_mu = float(np.median(data))
+                hat_mu = estimate_median(data, median_estimator)
 
             hat_sigma = estimate_sigma(
                 data=data,
@@ -252,12 +257,14 @@ def _run_hist_or_pmf(
                 ci_median_interval = ci_median_bootstrap(
                     data=data,
                     alpha=alpha,
+                    estimator=median_estimator,
                     B=bootstrap_samples,
                 )
             else:
                 ci_median_interval = ci_median_analytic(
                     data=data,
                     alpha=alpha,
+                    estimator=median_estimator,
                     sigma_estimator=sigma_estimator,
                 )
 
@@ -282,10 +289,10 @@ def _run_hist_or_pmf(
                     weights=weights,
                 )
             elif pi_choice == "Median":
-                # New API: pi_median only needs data, alpha and sigma_estimator
                 pi_interval = pi_median(
                     data=data,
                     alpha=alpha,
+                    estimator=median_estimator,
                     sigma_estimator=sigma_estimator,
                 )
             elif pi_choice == "IQR":
@@ -334,6 +341,7 @@ def _run_ecdf(
     ecdf_conf_level: float,
     ecdf_add_normal: bool,
     mean_estimator: str,
+    median_estimator: str,
     sigma_estimator: str,
     trim_param,
     winsor_limits,
@@ -364,7 +372,7 @@ def _run_ecdf(
                 weights=weights,
             )
         else:
-            hat_mu = float(np.median(data))
+            hat_mu = estimate_median(data, median_estimator)
 
         hat_sigma = estimate_sigma(
             data=data,

--- a/controllers/estimation/inference_controller.py
+++ b/controllers/estimation/inference_controller.py
@@ -93,12 +93,14 @@ def run_confidence_intervals(
         median_ci = ci_median_bootstrap(
             data=data,
             alpha=alpha,
+            estimator=median_estimator,
             B=bootstrap_samples,
         )
     else:
         median_ci = ci_median_analytic(
             data=data,
             alpha=alpha,
+            estimator=median_estimator,
             sigma_estimator=sigma_estimator,
         )
 
@@ -167,6 +169,7 @@ def run_prediction_intervals(
     median_pi = pi_median(
         data=data,
         alpha=alpha,
+        estimator=median_estimator,
         sigma_estimator=sigma_estimator,
     )
     rows.append(["Prediction", "Median", *median_pi])
@@ -273,7 +276,7 @@ def run_intervals(
     bootstrap_deviation,
     bootstrap_samples,
 ):
-    ci_table, mean_ci, sigma_ci = run_confidence_intervals(
+    ci_table, _, _, _ = run_confidence_intervals(
         data=data,
         alpha=alpha,
         mean_estimator=mean_estimator,

--- a/core/estimation/inference/ci_median.py
+++ b/core/estimation/inference/ci_median.py
@@ -3,13 +3,14 @@
 import numpy as np
 from scipy.stats import norm
 
-from .estimators import estimate_sigma
+from .estimators import estimate_median, estimate_sigma
 
 
 def ci_median_analytic(
     *,
     data,
     alpha,
+    estimator,
     sigma_estimator,
 ):
     """
@@ -18,10 +19,10 @@ def ci_median_analytic(
     Uses:
         Var(median) ≈ (π / 2) * σ² / n
 
-    σ is computed with the user-chosen deviation estimator.
+    Median and σ are computed with user-chosen estimators.
     """
     n = len(data)
-    median_hat = np.median(data)
+    median_hat = estimate_median(data, estimator)
 
     sigma_hat = estimate_sigma(
         data=data,
@@ -40,12 +41,13 @@ def ci_median_bootstrap(
     *,
     data,
     alpha,
+    estimator,
     B,
 ):
     n = len(data)
 
     boot_stats = np.array([
-        np.median(np.random.choice(data, size=n, replace=True))
+        estimate_median(np.random.choice(data, size=n, replace=True), estimator)
         for _ in range(B)
     ])
 

--- a/core/estimation/inference/estimators.py
+++ b/core/estimation/inference/estimators.py
@@ -117,6 +117,22 @@ def estimate_mean(
     raise ValueError(f"Unknown mean estimator: {estimator}")
 
 
+# -----------------
+# Median estimators
+# -----------------
+
+def estimate_median(
+    data,
+    estimator,
+):
+    data = np.asarray(data)
+
+    if estimator == "Sample Median":
+        return np.median(data)
+
+    raise ValueError(f"Unknown median estimator: {estimator}")
+
+
 # --------------------
 # Deviation estimators
 # --------------------

--- a/core/estimation/inference/pi_median.py
+++ b/core/estimation/inference/pi_median.py
@@ -3,26 +3,27 @@
 import numpy as np
 from scipy.stats import norm
 
-from .estimators import estimate_sigma
+from .estimators import estimate_median, estimate_sigma
 
 
 def pi_median(
     *,
     data,
     alpha,
+    estimator,
     sigma_estimator,
 ):
     """
-    Asymptotic prediction interval based on the sample median.
+    Asymptotic prediction interval based on the chosen median estimator.
 
     scale = sqrt(σ² + πσ² / (2n)) = σ * sqrt(1 + π/(2n))
 
-    σ is computed with the user-chosen deviation estimator.
+    Median and σ are computed with user-chosen estimators.
     """
     data = np.asarray(data)
     n = len(data)
 
-    median_hat = np.median(data)
+    median_hat = estimate_median(data, estimator)
 
     sigma_hat = estimate_sigma(
         data=data,

--- a/ui/tabs/estimation/graphical_tab.py
+++ b/ui/tabs/estimation/graphical_tab.py
@@ -16,6 +16,10 @@ def build(state):
         "Weighted Mean",
     ]
 
+    ALL_MEDIAN_ESTIMATORS = [
+        "Sample Median",
+    ]
+
     ALL_DEVIATION_ESTIMATORS = [
         "Deviation (1 ddof)",
         "Range (bias corrected)",
@@ -175,7 +179,7 @@ def build(state):
 
         median_select = gr.Dropdown(
             label="Median Estimator",
-            choices=["Sample Median"],
+            choices=ALL_MEDIAN_ESTIMATORS,
             value="Sample Median",
         )
 

--- a/ui/tabs/estimation/inference_tab.py
+++ b/ui/tabs/estimation/inference_tab.py
@@ -22,6 +22,10 @@ def build(state):
         "Weighted Mean",
     ]
 
+    ALL_MEDIAN_ESTIMATORS = [
+        "Sample Median",
+    ]
+
     ALL_DEVIATION_ESTIMATORS = [
         "Deviation (1 ddof)",
         "Range (bias corrected)",
@@ -153,7 +157,7 @@ def build(state):
 
             median_select = gr.Dropdown(
                 label="Median Estimator",
-                choices=["Sample Median"],
+                choices=ALL_MEDIAN_ESTIMATORS,
                 value="Sample Median",
             )
 


### PR DESCRIPTION
### Motivation
- Remove hardcoded median/estimator choices in core CI/PI logic so median estimation is controlled by user-selected options and decision logic lives in controllers.
- Ensure graphical and inference controllers (and the UI) consistently pass estimator choices for mean/median/sigma to core functions.

### Description
- Added `estimate_median` helper in `core/estimation/inference/estimators.py` and replaced direct `np.median` calls with estimator-driven calls in median CI/PI functions (`ci_median_*`, `pi_median`).
- Updated `core/estimation/inference/ci_median.py` and `core/estimation/inference/pi_median.py` to accept a `median_estimator` argument and use `estimate_median` in both analytic and bootstrap paths.
- Wired `median_estimator` through controllers by updating `controllers/estimation/inference_controller.py` and `controllers/estimation/graphical_controller.py` to pass the selected median estimator into CI/PI calls and to use estimator-based median for normal overlays; also fixed `run_intervals` unpacking to match the 4-value return from `run_confidence_intervals`.
- Standardized UI choices by introducing `ALL_MEDIAN_ESTIMATORS` in `ui/tabs/estimation/inference_tab.py` and `ui/tabs/estimation/graphical_tab.py` and binding the median dropdowns to that list so the UI exposes the estimator option consistently.

### Testing
- Ran `python -m py_compile` on modified modules which succeeded (no syntax errors).
- Ran `pytest -q` which failed in this environment due to missing optional dependencies (`pandas` and `gradio`), not due to the changes introduced.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c48786388331b92c89f5fc790f18)